### PR TITLE
Add example script to export webknossos volume annotations

### DIFF
--- a/scripts/export_annotation.py
+++ b/scripts/export_annotation.py
@@ -1,0 +1,35 @@
+import os
+import numpy as np
+import webknossos as wk
+from tifffile import imwrite
+
+ANNOTATION_ID = '<annotation_id>'
+SEGMENT_IDS = [1,2]
+MAG = wk.Mag('8-8-1')
+annotation_directory='~/example_export'
+
+with wk.client.context.webknossos_context(url=os.environ.get('WK_URL'),token=os.environ.get('WK_TOKEN')):
+    dataset = wk.Annotation.open_as_remote_dataset(
+        ANNOTATION_ID, 
+        annotation_type='Volume',
+        webknossos_url=os.environ.get('WK_URL')
+    )
+    mag_view = dataset.get_segmentation_layers()[0].get_mag(MAG)
+
+z = mag_view.bounding_box.topleft.z
+with mag_view.get_buffered_slice_reader() as reader:
+    for slice_data in reader:
+        print(slice_data)
+        slice_data = slice_data[0]  # First channel only
+        for segment_id in SEGMENT_IDS:
+            segment_mask = (slice_data == segment_id).astype(
+                np.uint8
+            ) * 255  # Make a binary mask 0=empty, 255=segment
+            segment_mask = segment_mask.T  # Tiff likes the data transposed
+            imwrite(
+                f"{annotation_directory}/seg{segment_id:04d}_mag{MAG}_z{z:04d}.tiff",
+                segment_mask,
+            )
+
+        print(f'Downloaded z={z:04d}')
+        z += MAG.z

--- a/scripts/export_annotation.py
+++ b/scripts/export_annotation.py
@@ -19,7 +19,6 @@ with wk.client.context.webknossos_context(url=os.environ.get('WK_URL'),token=os.
 z = mag_view.bounding_box.topleft.z
 with mag_view.get_buffered_slice_reader() as reader:
     for slice_data in reader:
-        print(slice_data)
         slice_data = slice_data[0]  # First channel only
         for segment_id in SEGMENT_IDS:
             segment_mask = (slice_data == segment_id).astype(


### PR DESCRIPTION
Hi @jingjingwu1225, here is an example script to export Webknossos annotations based on their [documentation](https://docs.webknossos.org/webknossos-py/examples/download_segments.html).   I have tested this on the LINC Jupyter Hub for the magnification level of `8-8-1` and all lower resolutions.  Please let me know if it crashes for higher resolution levels.

In order to run:
1. Install the following Python packages: `webknossos`, `tifffile`, and `numpy==1.26.1`
2. The `WK_TOKEN` can be found under the main menu under `Auth Token`:
  ![image](https://github.com/user-attachments/assets/ab128f43-46ea-4d69-9db0-49926777a0c8)
3. Use the command:
    ```bash
    WK_URL="https://webknossos.lincbrain.org" WK_TOKEN="<add_token>" python export_annotation.py
    ```

Please update the script to include the following changes:
1. Export to a single Zarr instead of TIFF files
2. Export all z slices to the same Zarr
3. Export all segment_ids to the same Zarr

cc @aaronkanzer @balbasty 