### PR TITLE
Oct mat to zarr

### DIFF
--- a/scripts/oct_mat_to_zarr.py
+++ b/scripts/oct_mat_to_zarr.py
@@ -125,7 +125,8 @@ def convert(
 
     if not hasattr(inp,"dtype"):
         raise Exception("Input is not a numpy array, converted. This is likely unexpected")
-
+    if len(inp.shape) < 3:
+        raise Exception("Input array is not 3d")
     # Prepare chunking options
     opt = {
         'dimension_separator': r'/',

--- a/scripts/oct_mat_to_zarr.py
+++ b/scripts/oct_mat_to_zarr.py
@@ -56,7 +56,7 @@ def automap(func):
 @automap
 def convert(
     inp: str,
-    out: str = None,
+    out: Optional[str] = None,
     *,
     key: str = None,
     meta: str = None,

--- a/scripts/oct_mat_to_zarr.py
+++ b/scripts/oct_mat_to_zarr.py
@@ -124,7 +124,7 @@ def convert(
     omz = zarr.group(store=omz, overwrite=True)
 
     if not hasattr(inp,"dtype"):
-        raise Exception("Input is not a numpy array, converted. This is likely unexpected")
+        raise Exception("Input is not a numpy array. This is likely unexpected")
     if len(inp.shape) < 3:
         raise Exception("Input array is not 3d")
     # Prepare chunking options

--- a/scripts/oct_mat_to_zarr.py
+++ b/scripts/oct_mat_to_zarr.py
@@ -41,9 +41,9 @@ def automap(func):
     """Decorator to automatically map the array in the mat file"""
 
     @wraps(func)
-    def wrapper(inp, out, **kwargs):
+    def wrapper(inp, out=None, **kwargs):
         if out is None:
-            out = os.path.splitext(inp)
+            out = os.path.splitext(inp)[0]
             out += '.nii.zarr' if kwargs.get('nii', False) else '.ome.zarr'
         kwargs['nii'] = kwargs.get('nii', False) or out.endswith('.nii.zarr')
         with mapmat(inp,kwargs.get('key', None)) as dat:

--- a/scripts/oct_mat_to_zarr.py
+++ b/scripts/oct_mat_to_zarr.py
@@ -325,7 +325,7 @@ def mapmat(fnames, key=None):
             # "Old" .mat file
             f = loadmat(fname)
         if key is None:
-            if len(f.keys()[0]) > 1:
+            if len(f.keys()) > 1:
                 warn(f'More than one key in .mat file {fname}, arbitrarily loading "{f.keys[0]}"')
             key = f.keys()[0]
 

--- a/scripts/oct_mat_to_zarr.py
+++ b/scripts/oct_mat_to_zarr.py
@@ -328,6 +328,8 @@ def mapmat(fnames, key=None):
             if len(f.keys()) > 1:
                 warn(f'More than one key in .mat file {fname}, arbitrarily loading "{f.keys[0]}"')
             key = f.keys()[0]
+        if key not in f.keys():
+            raise Exception(f"Key {key} not found in file {fname}")
 
         if len(fnames) == 1:
             yield f.get(key)

--- a/scripts/oct_mat_to_zarr.py
+++ b/scripts/oct_mat_to_zarr.py
@@ -58,7 +58,7 @@ def convert(
     inp: str,
     out: Optional[str] = None,
     *,
-    key: str = None,
+    key: Optional[str] = None,
     meta: str = None,
     chunk: int = 128,
     compressor: str = 'blosc',
@@ -80,6 +80,8 @@ def convert(
         Path to the input mat file
     out
         Path to the output Zarr directory [<INP>.ome.zarr]
+    key
+        Key of the array to be extracted, default to first key found
     meta
         Path to the metadata file
     chunk

--- a/scripts/oct_mat_to_zarr.py
+++ b/scripts/oct_mat_to_zarr.py
@@ -123,6 +123,9 @@ def convert(
     omz = zarr.storage.DirectoryStore(out)
     omz = zarr.group(store=omz, overwrite=True)
 
+    if not hasattr(inp,"dtype"):
+        raise Exception("Input is not a numpy array, converted. This is likely unexpected")
+
     # Prepare chunking options
     opt = {
         'dimension_separator': r'/',


### PR DESCRIPTION
Add the capabilities to handle multiple input files. In such case, we assume input array is 2d and stack them along a new 'z' axis. In addition, add a new argument 'key' to let the users select the desired key in .mat file(s). 