### PR TITLE
[MNT] Use extras instead of groups for optional dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         # glymur needs dynamic library on macos and windows, and causing error
         # os: [ubuntu-22.04, macos-latest, windows-latest]
         os: [ubuntu-22.04]
-        
+
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -34,7 +34,7 @@ jobs:
           path: ./.venv
           key: venv-${{ hashFiles('poetry.lock') }}
       - name: Install the project dependencies
-        run: poetry install --with dev,lsm,df,wk
+        run: poetry install --with dev --extras all
       - name: Run the automated tests
         run: poetry run pytest -v
         working-directory: ./tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ df = ["glymur"]
 lsm = ["tifffile"]
 psoct = ["h5py", "scipy"]
 wk = ["wkw"]
+all = ["dandi", "fsspec", "glymur", "tifffile", "h5py", "scipy", "wkw"]
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ df = ["glymur"]
 lsm = ["tifffile"]
 psoct = ["h5py", "scipy"]
 wk = ["wkw"]
-all = ["dandi", "fsspec", "glymur", "tifffile", "h5py", "scipy", "wkw"]
+all = ["glymur", "tifffile", "h5py", "scipy", "wkw"]
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,28 +28,18 @@ cyclopts = "^3.0.0"
 numpy = "*"
 nibabel = "*"
 zarr = "^2.0.0"
+# optionals
+glymur = { version = "*", optional = true }
+tifffile = { version = "*", optional = true }
+h5py = { version = "*", optional = true }
+scipy = { version = "*", optional = true }
+wkw = { version = "*", optional = true }
 
-
-[tool.poetry.group.df]
-optional = true
-[tool.poetry.group.df.dependencies]
-glymur = "*"
-
-[tool.poetry.group.lsm]
-optional = true
-[tool.poetry.group.lsm.dependencies]
-tifffile = "*"
-
-[tool.poetry.group.psoct]
-optional = true
-[tool.poetry.group.psoct.dependencies]
-h5py = "*"
-scipy = "*"
-
-[tool.poetry.group.wk]
-optional = true
-[tool.poetry.group.wk.dependencies]
-wkw = "*" 
+[tool.poetry.extras]
+df = ["glymur"]
+lsm = ["tifffile"]
+psoct = ["h5py", "scipy"]
+wk = ["wkw"]
 
 [tool.poetry.group.dev]
 optional = true
@@ -138,5 +128,5 @@ bump = true
 pattern = "default-unprefixed"
 
 [build-system]
-requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+requires = ["poetry-core>=1.0.0,<2.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
I've also explicitely set poetry-core to ">=1, <2", as we're currently using fields that are deprecated in poetry v2.

Happy to switch to v2 if preferred.