### PR TITLE
fix: zarr_config instance got removed in wrapper

### DIFF
--- a/linc_convert/modalities/psoct/single_volume.py
+++ b/linc_convert/modalities/psoct/single_volume.py
@@ -92,6 +92,8 @@ def convert(
         Orientation of the volume
     center
         Set RAS[0, 0, 0] at FOV center
+    zarr_config
+        ZarrConfig instance contains zarr-related config
     """
     zarr_config = update_default_config(zarr_config, **kwargs)
     zarr_config.set_default_name(os.path.splitext(inp.file)[0])


### PR DESCRIPTION
fix a small bug that blocks the documentation generation