### PR TITLE
Fix navigation for notebooks

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -44,6 +44,7 @@ plugins:
   - section-index
   - same-dir
   - mkdocs-jupyter:
+      ignore_h1_titles: True
       include: [ "*.ipynb" ]
   - mkdocstrings:
       handlers:


### PR DESCRIPTION
@calvinchai I was mistaken.  We should include the `ignore_h1_titles: True` option, so that the navigation header shows up as `PS-OCT Single Volume Demo` and not `LINC Convert — End‑to‑End Demo`.