### PR TITLE
Remove unimplemented zarrita driver from Zarr IO options

### DIFF
--- a/linc_convert/utils/io/zarr/drivers/zarrita.py
+++ b/linc_convert/utils/io/zarr/drivers/zarrita.py
@@ -1,3 +1,0 @@
-"""Zarrita driver for Zarr groups and arrays."""
-
-raise NotImplementedError

--- a/linc_convert/utils/zarr_config.py
+++ b/linc_convert/utils/zarr_config.py
@@ -18,7 +18,7 @@ from typing import (
 
 from cyclopts import Parameter
 
-DriverLike: TypeAlias = Literal["zarr-python", "tensorstore", "zarrita"]
+DriverLike: TypeAlias = Literal["zarr-python", "tensorstore"]
 
 @Parameter(name="*")
 @dataclass
@@ -77,7 +77,7 @@ class ZarrConfig:
     overwrite
         when no name is supplied and using default output name, if overwrite is set,
         it won't ask if overwrite
-    driver : {"zarr-python", "tensorstore", "zarrita"}
+    driver : {"zarr-python", "tensorstore"}
         library used for Zarr IO Operation
     """
 


### PR DESCRIPTION
Zarrita is no longer maintained so here I am removing references to zarrita in this package.

See zarrita's archived repo and note on the readme: https://github.com/scalableminds/zarrita/